### PR TITLE
Migrate to new JSONObject/JSONArray library

### DIFF
--- a/src/org/labkey/filetransfer/globus/GlobusFileTransferProvider.java
+++ b/src/org/labkey/filetransfer/globus/GlobusFileTransferProvider.java
@@ -31,7 +31,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.util.PageFlowUtil;


### PR DESCRIPTION
#### Rationale
We want to use the new `org.json.JSON*` library